### PR TITLE
Fix vpk file path making

### DIFF
--- a/vpk/__init__.py
+++ b/vpk/__init__.py
@@ -280,7 +280,7 @@ class VPK(object):
     def _make_vpkfile_path(self, metadata):
         path = self.vpk_path
 
-        if metadata.get('file_length', 0) > 0:
+        if metadata['archive_index'] != 0x7fff:
             path = path.replace('english','').replace("dir.", "%03d." % metadata['archive_index'])
 
         return path


### PR DESCRIPTION
We should check if the archive_index refers to the current archive (0x7fff) instead of checking if the file length is above 0. Currently the package sometimes tries to open archive index 32767 (0x7fff) which is obviously invalid.

The issue was found in lasa01/io_import_vmf#45.